### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ruby:2.1
 
-MAINTAINER oqpvq <o+docker@qp.vc>
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
@@ -9,8 +8,6 @@ CMD ["bash", "start.sh"]
 
 RUN apt-get update && apt-get install -y openjdk-7-jre-headless nodejs qt5-default libqt5webkit5-dev postgresql-client sqlite3 graphviz libxml2-dev libxslt-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/kekshd/keks.git .
+COPY ./ /usr/src/app
 RUN bundle install --deployment --without development
 RUN echo "GIT_REVISION='$(git rev-parse HEAD)'" > config/initializers/git_revision.rb
-
-


### PR DESCRIPTION
use copy instead of git clone to get the source code into the container. This allows us to have the same docker file for both branches (master and dev).